### PR TITLE
Fix Fedora instructions to install c++ compiler

### DIFF
--- a/Samples.md
+++ b/Samples.md
@@ -27,7 +27,7 @@ Platform   | ARM Toolchain  | Make  | dfu-util
 **Windows**    | [GNU Arm Embedded Toolchain](https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads) | [GNU Win32 Make](http://gnuwin32.sourceforge.net/packages/make.htm) | [precompiled binaries](http://dfu-util.sourceforge.net/releases/dfu-util-0.8-binaries/win32-mingw32/)
 **macOS**      | [GNU Arm Embedded Toolchain](https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads) | [Xcode](https://itunes.apple.com/us/app/xcode/id497799835) | [Homebrew](https://brew.sh/) `brew install dfu-util`
 **Debian/Ubuntu** | `sudo apt-get install gcc-arm-none-eabi libnewlib-arm-none-eabi` | `sudo apt-get install make` | `sudo apt-get install dfu-util`
-**Fedora** | `sudo dnf install arm-none-eabi-newlib  arm-none-eabi-gcc` | `sudo dnf install make` | `sudo dnf install dfu-util`
+**Fedora** | `sudo dnf install arm-none-eabi-newlib arm-none-eabi-gcc-cs-c++` | `sudo dnf install make` | `sudo dnf install dfu-util`
 **Arch** | `sudo pacman -S arm-none-eabi-gcc arm-none-eabi-newlib` | `sudo pacman -S make` | `sudo pacman -S dfu-util`
 
 Additionally, you may want to install `git`, or at least have a way to checkout git repositories.


### PR DESCRIPTION
The examples need g++ to be compiled.