### PR TITLE
Fix formatting issues with commands in markdown docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,6 @@ Developing Locally
 
 Following the [Github Documentation on Developing Locally](https://help.github.com/articles/setting-up-your-github-pages-site-locally-with-jekyll/), perform the following steps on this repo once checked out:
 
-1. Ensure ruby is installed.  On Ubuntu/Debian, run sudo apt install ruby ruby-dev make gcc libcurl3 autoconf libz-dev ruby-bundler
-1. bundle install --path vendor/bundle
-1. bundle exec jekyll serve
+1. Ensure ruby is installed.  On Ubuntu/Debian, run `sudo apt install ruby ruby-dev make gcc libcurl3 autoconf libz-dev ruby-bundler`
+1. `bundle install --path vendor/bundle`
+1. `bundle exec jekyll serve`

--- a/index.md
+++ b/index.md
@@ -60,13 +60,13 @@ To use the serial bootloader, Windows users will need to install Silabs-CDC_Inst
 
 ### Toboot (DFU Bootloader)
 
-The name of the DFU bootloader is [Toboot](https://github.com/im-tomu/tomu-bootloader).  DFU is a USB standard for updating firmware on a device.  The canonical program to use is dfu-util, which is in most major Linux distributions.  When Tomu is in Bootloader mode, it will flash red/green, and show up when you run **dfu-util -l**.
+The name of the DFU bootloader is [Toboot](https://github.com/im-tomu/tomu-bootloader).  DFU is a USB standard for updating firmware on a device.  The canonical program to use is dfu-util, which is in most major Linux distributions.  When Tomu is in Bootloader mode, it will flash red/green, and show up when you run `dfu-util -l`.
 
 ![Toboot DFU mode](img/toboot-mode.gif)
 
 **Version 1.0 of Toboot will auto-run a program if one exists**.  That means that once you load the Sample program, Toboot will always run the sample program.  To get back into Toboot, you will need to connect both capacitive buttons when you apply power.  Tweezers are useful here.  A future version of Toboot will have a "developer mode" that will cause it to always boot into DFU mode.
 
-To load a program, run **dfu-util -D [program].bin**.  Toboot will flash the new program onto your Tomu and reboot.  Don't worry if you flash the wrong file, or flash an invalid program -- Toboot will detect this and reboot into DFU mode if the file you flash fails to run.
+To load a program, run `dfu-util -D [program].bin`.  Toboot will flash the new program onto your Tomu and reboot.  Don't worry if you flash the wrong file, or flash an invalid program -- Toboot will detect this and reboot into DFU mode if the file you flash fails to run.
 
 <hr><br><br>
 
@@ -98,19 +98,19 @@ The U2F firmware source is located on Github in [im-tomu/chopstx/u2f](https://gi
 
 ### Building
 
-To build the U2F firmware, ensure you have an ARM compiler installed (e.g. *sudo apt install gcc-arm-none-eabi*) as well as Python pip (e.g. *pip install --user --upgrade asn1crypto*), then run:
+To build the U2F firmware, ensure you have an ARM compiler installed (e.g. `sudo apt install gcc-arm-none-eabi`) as well as Python pip (e.g. `pip install --user --upgrade asn1crypto`), then run:
 
-1. pip install --user --upgrade asn1crypto
-1. git clone https://github.com/im-tomu/chopstx.git tomu-u2f
-1. cd tomu-u2f/u2f
-1. make
+1. `pip install --user --upgrade asn1crypto`
+1. `git clone https://github.com/im-tomu/chopstx.git tomu-u2f`
+1. `cd tomu-u2f/u2f`
+1. `make`
 
 ### Loading onto Tomu
 
-The build system produces an output file *build/u2f.bin*.  Upload this file to Tomu.
+The build system produces an output file build/u2f.bin.  Upload this file to Tomu.
 
 * If using the serial bootloader, type **u** and send the file using XMODEM
-* If using the DFU bootloader, reboot into DFU mode and run **dfu-util -D build/u2f.bin**
+* If using the DFU bootloader, reboot into DFU mode and run `dfu-util -D build/u2f.bin`
 
 <hr><br><br>
 


### PR DESCRIPTION
Some commands were not wrapped in backticks, and consequently
some `--double-hyphen` args were converted to em-dash during compilation
to HTML.